### PR TITLE
Logger Abstract Factory Pattern 적용

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactoryPattern.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactoryPattern.java
@@ -1,5 +1,0 @@
-package com.mendhak.gpslogger.loggers;
-
-public abstract class FileLoggerFactoryPattern {
-    abstract FileLogger createFileLogger();
-}

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactoryPattern.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactoryPattern.java
@@ -1,0 +1,5 @@
+package com.mendhak.gpslogger.loggers;
+
+public abstract class FileLoggerFactoryPattern {
+    abstract FileLogger createFileLogger();
+}

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactoryPattern/FileLoggerFactoryContext.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactoryPattern/FileLoggerFactoryContext.java
@@ -1,0 +1,9 @@
+package com.mendhak.gpslogger.loggers.FileLoggerFactoryPattern;
+
+import android.content.Context;
+
+import com.mendhak.gpslogger.loggers.FileLogger;
+
+public abstract class FileLoggerFactoryContext {
+    public abstract FileLogger getFileLogger(Context context);
+}

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactoryPattern/FileLoggerFactoryFileBool.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactoryPattern/FileLoggerFactoryFileBool.java
@@ -1,0 +1,9 @@
+package com.mendhak.gpslogger.loggers.FileLoggerFactoryPattern;
+
+import com.mendhak.gpslogger.loggers.FileLogger;
+
+import java.io.File;
+
+public abstract class FileLoggerFactoryFileBool {
+    public abstract FileLogger getFileLogger(File file, boolean setAddNewTrackSegment);
+}

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/geojson/GeoJSONLoggerFactory.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/geojson/GeoJSONLoggerFactory.java
@@ -1,0 +1,15 @@
+package com.mendhak.gpslogger.loggers.geojson;
+
+import com.mendhak.gpslogger.loggers.FileLogger;
+import com.mendhak.gpslogger.loggers.FileLoggerFactory;
+import com.mendhak.gpslogger.loggers.FileLoggerFactoryPattern.FileLoggerFactoryFileBool;
+
+import java.io.File;
+
+public class GeoJSONLoggerFactory extends FileLoggerFactoryFileBool {
+
+    @Override
+    public FileLogger getFileLogger(File file, boolean setAddNewTrackSegment) {
+        return new GeoJSONLogger(file, setAddNewTrackSegment);
+    }
+}

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx10FileLoggerFactory.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx10FileLoggerFactory.java
@@ -1,0 +1,13 @@
+package com.mendhak.gpslogger.loggers.gpx;
+
+import com.mendhak.gpslogger.loggers.FileLogger;
+import com.mendhak.gpslogger.loggers.FileLoggerFactoryPattern.FileLoggerFactoryFileBool;
+
+import java.io.File;
+
+public class Gpx10FileLoggerFactory extends FileLoggerFactoryFileBool {
+    @Override
+    public FileLogger getFileLogger(File file, boolean setAddNewTrackSegment) {
+        return new Gpx10FileLogger(file, setAddNewTrackSegment);
+    }
+}

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx11FileLoggerFactory.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx11FileLoggerFactory.java
@@ -1,0 +1,14 @@
+package com.mendhak.gpslogger.loggers.gpx;
+
+import com.mendhak.gpslogger.loggers.FileLogger;
+import com.mendhak.gpslogger.loggers.FileLoggerFactoryPattern.FileLoggerFactoryFileBool;
+
+import java.io.File;
+
+public class Gpx11FileLoggerFactory extends FileLoggerFactoryFileBool {
+
+    @Override
+    public FileLogger getFileLogger(File file, boolean setAddNewTrackSegment) {
+        return new Gpx11FileLogger(file, setAddNewTrackSegment);
+    }
+}

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/kml/Kml22FileLoggerFactory.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/kml/Kml22FileLoggerFactory.java
@@ -1,0 +1,14 @@
+package com.mendhak.gpslogger.loggers.kml;
+
+import com.mendhak.gpslogger.loggers.FileLogger;
+import com.mendhak.gpslogger.loggers.FileLoggerFactoryPattern.FileLoggerFactoryFileBool;
+
+import java.io.File;
+
+public class Kml22FileLoggerFactory extends FileLoggerFactoryFileBool {
+
+    @Override
+    public FileLogger getFileLogger(File file, boolean setAddNewTrackSegment) {
+        return new Kml22FileLogger(file, setAddNewTrackSegment);
+    }
+}

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/opengts/OpenGTSLoggerFactory.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/opengts/OpenGTSLoggerFactory.java
@@ -1,0 +1,14 @@
+package com.mendhak.gpslogger.loggers.opengts;
+
+import android.content.Context;
+
+import com.mendhak.gpslogger.loggers.FileLogger;
+import com.mendhak.gpslogger.loggers.FileLoggerFactoryPattern.FileLoggerFactoryContext;
+
+public class OpenGTSLoggerFactory extends FileLoggerFactoryContext{
+
+    @Override
+    public FileLogger getFileLogger(Context context) {
+        return new OpenGTSLogger(context);
+    }
+}

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/wear/AndroidWearLoggerFactory.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/wear/AndroidWearLoggerFactory.java
@@ -1,0 +1,14 @@
+package com.mendhak.gpslogger.loggers.wear;
+
+import android.content.Context;
+
+import com.mendhak.gpslogger.loggers.FileLogger;
+import com.mendhak.gpslogger.loggers.FileLoggerFactoryPattern.FileLoggerFactoryContext;
+
+public class AndroidWearLoggerFactory extends FileLoggerFactoryContext {
+
+    @Override
+    public FileLogger getFileLogger(Context context) {
+        return new AndroidWearLogger(context);
+    }
+}


### PR DESCRIPTION
1. Abstract Factory Pattern
 2. GeoJSONLogger, Gpx10FileLogger, Gpx11FileLogger, Kml22FileLogger
 3. interface인 FileLogger를 implements하는 Logger들을 생성하는데 별도의 factory가 존재하지 않아 직접 객체를 생성해 사용해야 한다. 또한 FileLoggerFactory라는 클래스가 존재하나 이 클래스는 원 제작자의 어떠한 의도를 위한 것이지 Factory Pattern의 적용을 위한 것이 아닌 것으로 확인되어 Factory Pattern을 적용하였다.

  1. Abstract Factory Pattern
  2. OpenGTSLogger, AndroidWearLogger
  3. interface인 FileLogger를 implements하는 Logger들을 생성하는데 별도의 factory가 존재하지 않아 직접 객체를 생성해 사용해야 한다. 또한 FileLoggerFactory라는 클래스가 존재하나 이 클래스는 원 제작자의 어떠한 의도를 위한 것이지 Factory Pattern의 적용을 위한 것이 아닌 것으로 확인되어 Factory Pattern을 적용하였다.